### PR TITLE
Add ruby-webrick to installed apks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ RUN eval $(ssh-agent -s)
 RUN export LC_ALL=en_US.UTF-8 \
     export LANG=en_US.UTF-8
 
+RUN apk add ruby-webrick

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --update --no-cache \
     git \
     bash \
     openssh-client \
+    ruby-webrick \
     && rm -rf /tmp/* /var/tmp/* \
     && echo 'gem: --no-document' > /etc/gemrc
 
@@ -19,5 +20,3 @@ RUN eval $(ssh-agent -s)
 
 RUN export LC_ALL=en_US.UTF-8 \
     export LANG=en_US.UTF-8
-
-RUN apk add ruby-webrick


### PR DESCRIPTION
Using certain bundle commands suck as `bundle exec fastlane update_plugins` caused the following error: `LoadError: cannot load such file -- webrick/httputils`.

It seems this "important gem" is only bundled with `ruby-full` package now.
See 
https://github.com/gliderlabs/docker-alpine/issues/431#issuecomment-412733498
https://pkgs.alpinelinux.org/package/edge/main/x86/ruby-webrick 